### PR TITLE
deprecated TrustBadgeList. fix + toggable type.USAGE fix + granted fix

### DIFF
--- a/orange_edo_demo_otb/src/main/java/com/orange/essentials/demo/otb/CustomBadgeFactory.java
+++ b/orange_edo_demo_otb/src/main/java/com/orange/essentials/demo/otb/CustomBadgeFactory.java
@@ -93,6 +93,7 @@ public class CustomBadgeFactory {
                 customBadge3.setEnabledIconId(R.drawable.ic_contacts_black_32dp);
                 customBadge3.setDisabledIconId(R.drawable.ic_contacts_black_32dp);
                 customBadge3.setAppUsesPermission(AppUsesPermission.TRUE);
+                customBadge3.setToggable(true);
                 mTrustBadgeElements.add(customBadge3);
             }
         }

--- a/orange_edo_demo_otb/src/main/java/com/orange/essentials/demo/otb/MainActivity.java
+++ b/orange_edo_demo_otb/src/main/java/com/orange/essentials/demo/otb/MainActivity.java
@@ -98,8 +98,6 @@ public class MainActivity extends AppCompatActivity implements BadgeListener {
                 SharedPreferences.Editor editor = sp.edit();
                 editor.putBoolean(trustBadgeElement.getNameKey(), value);
                 editor.apply();
-                //Change the UserPermissionStatus as it has been switched by user
-                trustBadgeElement.setUserPermissionStatus(value ? UserPermissionStatus.GRANTED : UserPermissionStatus.NOT_GRANTED);
             }
         }
     }

--- a/orange_edo_demo_otb/src/main/java/com/orange/essentials/demo/otb/dialog/OtbImprovementDialogFragment.java
+++ b/orange_edo_demo_otb/src/main/java/com/orange/essentials/demo/otb/dialog/OtbImprovementDialogFragment.java
@@ -60,6 +60,7 @@ public class OtbImprovementDialogFragment extends DialogFragment {
             public void onClick(View v) {
                 Log.d(TAG, "onClick Cancel");
                 TrustBadgeManager.INSTANCE.badgeChanged(TrustBadgeManager.INSTANCE.getSpecificPermission(GroupType.IMPROVEMENT_PROGRAM), true, (AppCompatActivity) getActivity());
+                TrustBadgeManager.INSTANCE.badgeChanged(GroupType.IMPROVEMENT_PROGRAM, true, (AppCompatActivity) getActivity());
                 dismiss();
             }
         });

--- a/otb/src/main/java/com/orange/essentials/otb/manager/TrustBadgeManager.java
+++ b/otb/src/main/java/com/orange/essentials/otb/manager/TrustBadgeManager.java
@@ -357,6 +357,8 @@ public enum TrustBadgeManager {
                 mBadgeListeners.get(i).onBadgeChange(trustBadgeElement, toggled, callingActivity);
             }
         }
+        //Change the UserPermissionStatus as it has been switched by user
+        trustBadgeElement.setUserPermissionStatus(toggled ? UserPermissionStatus.GRANTED : UserPermissionStatus.NOT_GRANTED);
     }
 
     public List<BadgeListener> getBadgeListeners() {
@@ -375,6 +377,11 @@ public enum TrustBadgeManager {
         }
     }
 
+    /**
+     * @deprecated use rather the interface BadgeListener, called by
+     * badgeChanged(TrustBadgeElement trustBadgeElement, boolean toggled, AppCompatActivity callingActivity)
+     */
+    @Deprecated
     public void badgeChanged(GroupType groupType, boolean toggled, AppCompatActivity callingActivity) {
         if (null != mTrustBadgeElementListeners) {
             for (int i = 0; i < mTrustBadgeElementListeners.size(); i++) {

--- a/otb/src/main/java/com/orange/essentials/otb/ui/OtbDataFragment.java
+++ b/otb/src/main/java/com/orange/essentials/otb/ui/OtbDataFragment.java
@@ -162,6 +162,7 @@ public class OtbDataFragment extends Fragment {
                                 }
                                 TrustBadgeManager.INSTANCE.getEventTagger().tagElement(EventType.TRUSTBADGE_ELEMENT_TOGGLED, data);
                                 TrustBadgeManager.INSTANCE.badgeChanged(data, isChecked, (AppCompatActivity) getActivity());
+                                TrustBadgeManager.INSTANCE.badgeChanged(data.getGroupType(), isChecked, (AppCompatActivity) getActivity());
                             }
                         }
                 );


### PR DESCRIPTION
- deprecated TrustBadgeListener was broken in V1.1
- toggable in ElementType.USAGE list were not working
- GRANTED status was not switched automatically when activating/deactivating a toggle.
